### PR TITLE
Add ability to update the agent manager with workflow graph

### DIFF
--- a/evoagentx/agents/agent_manager.py
+++ b/evoagentx/agents/agent_manager.py
@@ -11,7 +11,6 @@ from ..core.module import BaseModule
 from ..core.decorators import atomic_method
 from ..storages.base import StorageHandler
 from ..models.model_configs import LLMConfig
-from ..workflow.workflow_graph import WorkFlowGraph
 
 class AgentState(str, Enum):
     AVAILABLE = "available"
@@ -374,7 +373,7 @@ class AgentManager(BaseModule):
             )
 
 
-    def update_agents_from_workflow(self, workflow_graph: WorkFlowGraph, llm_config: Optional[LLMConfig]=None, **kwargs):
+    def update_agents_from_workflow(self, workflow_graph, llm_config: Optional[LLMConfig]=None, **kwargs):
         """
         Update agents from a given WorkFlowGraph.
 
@@ -383,6 +382,7 @@ class AgentManager(BaseModule):
             llm_config (Optional[LLMConfig]): The LLM configuration to be used for the agents.
             **kwargs: Additional parameters passed to update_agent
         """
+        from ..workflow.workflow_graph import WorkFlowGraph
         if not isinstance(workflow_graph, WorkFlowGraph):
             raise TypeError("workflow_graph must be an instance of WorkFlowGraph")
         for node in workflow_graph.nodes:

--- a/evoagentx/agents/agent_manager.py
+++ b/evoagentx/agents/agent_manager.py
@@ -246,6 +246,29 @@ class AgentManager(BaseModule):
             if node.agents:
                 for agent in node.agents:
                     self.add_agent(agent=agent, llm_config=llm_config, **kwargs)
+    
+    def update_agents_from_workflow(self, workflow_graph, llm_config: Optional[LLMConfig]=None, **kwargs):
+        """
+        Update agents from a given WorkFlowGraph.
+
+        Args:
+            workflow_graph (WorkFlowGraph): The workflow graph containing nodes with agents information.
+            llm_config (Optional[LLMConfig]): The LLM configuration to be used for the agents.
+            **kwargs: Additional parameters passed to update_agent
+        """
+        from ..workflow.workflow_graph import WorkFlowGraph
+        if not isinstance(workflow_graph, WorkFlowGraph):
+            raise TypeError("workflow_graph must be an instance of WorkFlowGraph")
+        for node in workflow_graph.nodes:
+            if node.agents:
+                for agent in node.agents:
+                    agent_name = self.get_agent_name(agent=agent)
+                    if self.has_agent(agent_name=agent_name):
+                        # use the llm_config of the existing agent
+                        agent_llm_config = self.get_agent(agent_name).llm_config
+                        self.update_agent(agent=agent, llm_config=agent_llm_config, **kwargs)
+                    else:
+                        self.add_agent(agent=agent, llm_config=llm_config, **kwargs)
 
     def get_agent(self, agent_name: str, **kwargs) -> Agent:
         """Retrieve an agent by its name from managed agents.
@@ -263,6 +286,20 @@ class AgentManager(BaseModule):
             if agent.name == agent_name:
                 return agent
         raise ValueError(f"Agent ``{agent_name}`` does not exists!")
+    
+    def update_agent(self, agent: Union[dict, Agent], llm_config: Optional[LLMConfig]=None, **kwargs):
+        """
+        Update an agent in the manager.
+
+        Args:
+            agent: The agent to be updated, specified as:
+                - Dictionary: Agent specification to update a CustomizeAgent
+                - Agent: Existing Agent instance to update
+            llm_config (Optional[LLMConfig]): The LLM configuration to be used for the agent.
+        """
+        agent_name = self.get_agent_name(agent=agent)
+        self.remove_agent(agent_name=agent_name)
+        self.add_agent(agent=agent, llm_config=llm_config, **kwargs)
     
     @atomic_method
     def remove_agent(self, agent_name: str, remove_from_storage: bool=False, **kwargs):
@@ -372,36 +409,3 @@ class AgentManager(BaseModule):
                 timeout=timeout
             )
 
-
-    def update_agents_from_workflow(self, workflow_graph, llm_config: Optional[LLMConfig]=None, **kwargs):
-        """
-        Update agents from a given WorkFlowGraph.
-
-        Args:
-            workflow_graph (WorkFlowGraph): The workflow graph containing nodes with agents information.
-            llm_config (Optional[LLMConfig]): The LLM configuration to be used for the agents.
-            **kwargs: Additional parameters passed to update_agent
-        """
-        from ..workflow.workflow_graph import WorkFlowGraph
-        if not isinstance(workflow_graph, WorkFlowGraph):
-            raise TypeError("workflow_graph must be an instance of WorkFlowGraph")
-        for node in workflow_graph.nodes:
-            if node.agents:
-                for agent in node.agents:
-                    self.update_agent(agent=agent, llm_config=llm_config, **kwargs)
-
-
-    def update_agent(self, agent: Union[dict, Agent], llm_config: Optional[LLMConfig]=None, **kwargs):
-        """
-        Update an agent in the manager.
-
-        Args:
-            agent: The agent to be updated, specified as:
-                - Dictionary: Agent specification to update a CustomizeAgent
-                - Agent: Existing Agent instance to update
-            llm_config (Optional[LLMConfig]): The LLM configuration to be used for the agent.
-        """
-        agent_name = self.get_agent_name(agent=agent)
-        self.remove_agent(agent_name=agent_name)
-        self.add_agent(agent=agent, llm_config=llm_config, **kwargs)
-        

--- a/evoagentx/evaluators/evaluator.py
+++ b/evoagentx/evaluators/evaluator.py
@@ -28,7 +28,6 @@ class Evaluator:
         agent_manager: Optional[AgentManager] = None,
         collate_func: Optional[Callable] = None, 
         output_postprocess_func: Optional[Callable] = None, 
-        update_agent_manager: bool = True,
         verbose: Optional[bool] = None, 
         **kwargs
     ):
@@ -48,13 +47,11 @@ class Evaluator:
                 It receives the output of an WorkFlow instance (str) or an ActionGraph instance (dict) as input 
                 and the output will be passed to the `evaluate` function of the benchmark. 
                 The default is a lambda function that returns the output itself.
-            update_agent_manager (bool): Whether to update the agent manager with agents from the workflow graph.
             verbose (bool, optional): Whether to print the evaluation progress.
         """
         self.llm = llm
         self.num_workers = num_workers
         self.agent_manager = agent_manager
-        self.update_agent_manager = update_agent_manager
         self._thread_agent_managers = {}
         self.collate_func = collate_func or (lambda x: x)
         self.output_postprocess_func = output_postprocess_func or (lambda x: x)
@@ -83,6 +80,7 @@ class Evaluator:
         sample_k: Optional[int] = None, 
         seed: Optional[int] = None, 
         verbose: Optional[bool] = None,
+        update_agents: Optional[bool] = False,
         **kwargs
     ) -> dict:
         """
@@ -95,21 +93,19 @@ class Evaluator:
             indices (List[int], optional): The indices of the data to evaluate the workflow on.
             sample_k (int, optional): The number of data to evaluate the workflow on. If provided, a random sample of size `sample_k` will be used.
             verbose (bool, optional): Whether to print the evaluation progress. If not provided, the `self.verbose` will be used.
-        
+            update_agents (bool, optional): Whether to update the agents in the agent manager. Only used when the workflow graph is a WorkFlowGraph.
         Returns:
             dict: The average metrics of the workflow evaluation.
         """
         # clear the evaluation records
         self._evaluation_records.clear()
 
-        if isinstance(graph, WorkFlowGraph):
+        # update the agents in the agent manager
+        if isinstance(graph, WorkFlowGraph) and update_agents:
             if self.agent_manager is None:
-                self.agent_manager = AgentManager()
-                self.agent_manager.add_agents_from_workflow(graph, llm_config=self.llm.config)
-            else:
-                if self.update_agent_manager:
-                    self.agent_manager.update_agents_from_workflow(graph, llm_config=self.llm.config)
-            
+                raise ValueError(f"`agent_manager` is not provided in {type(self).__name__}. Please provide an agent manager when evaluating a WorkFlowGraph.")
+            self.agent_manager.update_agents_from_workflow(workflow_graph=graph, llm_config=self.llm.config, **kwargs)
+        
         data = self._get_eval_data(benchmark=benchmark, eval_mode=eval_mode, indices=indices, sample_k=sample_k, seed=seed)
         results = self._evaluate_graph(graph=graph, data=data, benchmark=benchmark, verbose=verbose, **kwargs)
         return results
@@ -127,7 +123,7 @@ class Evaluator:
             str: The output of the workflow graph
         """
         if self.agent_manager is None:
-            raise ValueError("`agent_manager` is not provided. Please provide an agent manager when evaluating a WorkFlowGraph.")
+            raise ValueError(f"`agent_manager` is not provided in {type(self).__name__}. Please provide an agent manager when evaluating a WorkFlowGraph.")
         
         # create a WorkFlow instance
         graph_copy = WorkFlowGraph(goal=graph.goal, graph=graph)


### PR DESCRIPTION
Add the ability to update the agent manager with workflow graph, and an option for the evaluator. This is helpful when the agent manager given to the evaluator at initialization may be outdated. For example, when using the same evaluator before and after optimizing the workflow graph, the agent manager used by the evaluator would only have the old prompts from before the optimization.