### PR TITLE
Quick Fix Against Unexpected

### DIFF
--- a/evoagentx/models/openrouter_model.py
+++ b/evoagentx/models/openrouter_model.py
@@ -21,7 +21,7 @@ class OpenRouterLLM(BaseLLM):
     def init_model(self):
         config: OpenRouterConfig = self.config
         self._client = self._init_client(config)
-        self._default_ignore_fields = ["llm_type", "openrouter_key", "openrouter_base", "output_response"]
+        self._default_ignore_fields = ["llm_type", "openrouter_key", "openrouter_base", "openrouter_model_base", "output_response"]
     
     def _init_client(self, config: OpenRouterConfig):
         client = OpenAI(


### PR DESCRIPTION
Hi Jinyuan,

I did a quick fix against the unexpected "openrouter_model_base" problem.

# Fix OpenRouterLLM parameter validation error

## Problem
The `OpenRouterLLM` class was failing with the error:

    Error during single_generate_async of OpenRouterLLM: Completions.create() got an unexpected keyword argument 'openrouter_model_base'

## Root Cause
The `openrouter_model_base` field from `OpenRouterConfig` was not included in the `_default_ignore_fields` list, causing it to be passed to the OpenAI client's `chat.completions.create()` method as an invalid parameter.

## Solution
Added `"openrouter_model_base"` to the `_default_ignore_fields` list in the `OpenRouterLLM.init_model()` method.

## Changes
- **File**: `evoagentx/models/openrouter_model.py`
- **Line**: 26
- **Change**: Updated `_default_ignore_fields` to include `"openrouter_model_base"`
