### PR TITLE
Correct an error in sew_optimizer.py

### DIFF
--- a/examples/sew_optimizer.py
+++ b/examples/sew_optimizer.py
@@ -35,7 +35,7 @@ def main():
     # obtain SEW workflow 
     sew_graph = SEWWorkFlowGraph(llm_config=llm_config)
     agent_manager = AgentManager()
-    agent_manager.add_agents_from_workflow(sew_graph)
+    agent_manager.add_agents_from_workflow(sew_graph, llm_config=llm_config)
 
     # obtain HumanEval benchmark
     humaneval = HumanEvalSplits()


### PR DESCRIPTION
Hi, I find that if we do not set up LLM config in sew agent:

```
agent_manager.add_agents_from_workflow(sew_graph, llm_config=llm_config)
```

There will be an error:

```
ValueError: When providing an agent as a dictionary, you must either include 'llm_config' in the dictionary or provide it as a parameter.
```

Now this error has been fixed.