### PR TITLE
Fix invalid type error for `dimensions` in `OpenAIEmbedding`

### DIFF
--- a/evoagentx/rag/embeddings/openai_embedding.py
+++ b/evoagentx/rag/embeddings/openai_embedding.py
@@ -1,12 +1,13 @@
 import os
 import warnings
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
-from openai import OpenAI
 from llama_index.core.embeddings import BaseEmbedding
+from openai import NOT_GIVEN, OpenAI
 
 from evoagentx.core.logging import logger
-from .base import BaseEmbeddingWrapper, EmbeddingProvider, SUPPORTED_MODELS
+
+from .base import SUPPORTED_MODELS, BaseEmbeddingWrapper, EmbeddingProvider
 
 # Mapping of default embedding dimensions for OpenAI models
 MODEL_DIMENSIONS = {
@@ -80,7 +81,7 @@ class OpenAIEmbedding(BaseEmbedding):
             response = self.client.embeddings.create(
                 input=[query],
                 model=self.model_name,
-                dimensions=self.dimensions,
+                dimensions=self.dimensions or NOT_GIVEN,
                 **self.kwargs
             )
             return response.data[0].embedding
@@ -95,7 +96,7 @@ class OpenAIEmbedding(BaseEmbedding):
             response = self.client.embeddings.create(
                 input=[text],
                 model=self.model_name,
-                dimensions=self.dimensions,
+                dimensions=self.dimensions or NOT_GIVEN,
                 **self.kwargs
             )
             return response.data[0].embedding
@@ -114,7 +115,7 @@ class OpenAIEmbedding(BaseEmbedding):
             response = self.client.embeddings.create(
                 input=texts,
                 model=self.model_name,
-                dimensions=self.dimensions,
+                dimensions=self.dimensions or NOT_GIVEN,
                 **self.kwargs
             )
             return [item.embedding for item in response.data]


### PR DESCRIPTION
## Summary
This PR resolves an issue where using `OpenAIEmbedding` in a RAG pipeline could trigger an invalid type error if the `dimensions` parameter is not specified by the user.

## Issue
When users use `OpenAIEmbedding` in a RAG pipeline and do not provide a `dimensions` value, the following error is encountered:
```
Failed to encode texts: Error code: 400 - {'success': False, 'error': {'name': 'ZodError', 'message': '[\n  {\n    "expected": "number",\n    "code": "invalid_type",\n    "path": [\n      "dimensions"\n    ],\n    "message": "Invalid input: expected number, received null"\n  }\n]'}}
```
This issue arises because, when `dimensions` is not specified, the value is passed as `None` to the OpenAI client. OpenAI distinguishes between omitted arguments and those explicitly set to `None`. As a result, the client expects a number for `dimensions`, but receives `None`, leading to the type error.

## Fix
To resolve this, we’ve updated the handling of the `dimensions` parameter. When `dimensions` is not provided (i.e., is `None`), we now set it to `NOT_GIVEN` when passing it to the OpenAI client. `NOT_GIVEN` is a special variable provided by OpenAI that indicates an omitted argument. This prevents the OpenAI client from receiving `None` as the value for `dimensions` and avoids the type error.