### PR TITLE
fix(optimizers): deepcopy mutated value in MapElitesOptimizer._mutate_cfg

### DIFF
--- a/evoagentx/optimizers/map_elites_optimizer.py
+++ b/evoagentx/optimizers/map_elites_optimizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+import copy
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 

--- a/evoagentx/optimizers/map_elites_optimizer.py
+++ b/evoagentx/optimizers/map_elites_optimizer.py
@@ -170,5 +170,5 @@ class MapElitesOptimizer(BaseOptimizer):
             return cfg
         current = cfg.get(key)
         alternatives = [v for v in choices if v != current]
-        cfg[key] = random.choice(alternatives) if alternatives else current
+        cfg[key] = copy.deepcopy(random.choice(alternatives)) if alternatives else current
         return cfg


### PR DESCRIPTION
## Summary

- Fixes incomplete deepcopy in `_mutate_cfg` where the newly chosen value for the mutated key was assigned without `copy.deepcopy()`
- `_random_cfg` already correctly uses `copy.deepcopy(random.choice(values))` — this brings `_mutate_cfg` in line with that

Closes #231

## Test plan

- [ ] Verify `_mutate_cfg` with mutable search space values (e.g., dicts/lists) no longer mutates the original `search_space` entries
- [ ] Run existing `tests/test_map_elites_optimizer.py` (or `tests/src/optimizers/test_map_elites_optimizer.py` after PR #230 merges)