### PR TITLE
fix(models): replace get_event_loop() with get_running_loop() and fix LSP violation in get_stream_output

### DIFF
--- a/evoagentx/models/openai_model.py
+++ b/evoagentx/models/openai_model.py
@@ -152,7 +152,7 @@ class OpenAILLM(BaseLLM):
             completion_params = self.get_completion_params(**kwargs)
 
             # Use synchronous client in async context to avoid issues
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             response = await loop.run_in_executor(
                 None, 
                 lambda: isolated_client.chat.completions.create(

--- a/evoagentx/models/siliconflow_model.py
+++ b/evoagentx/models/siliconflow_model.py
@@ -40,7 +40,7 @@ class SiliconFlowLLM(OpenAILLM):
                 **completion_params
             )
             if stream:
-                output, stream_response = self.get_stream_output(response, output_response=output_response)
+                output, stream_response = self._get_stream_output_with_response(response, output_response=output_response)
                 cost = self._completion_cost(stream_response)
             else:
                 output: str = response.choices[0].message.content
@@ -104,7 +104,11 @@ class SiliconFlowLLM(OpenAILLM):
 
         return cost_info
 
-    def get_stream_output(self, response: Stream, output_response: bool=True) -> Tuple[str, object]:
+    def get_stream_output(self, response: Stream, output_response: bool=True) -> str:
+        output, _ = self._get_stream_output_with_response(response, output_response=output_response)
+        return output
+
+    def _get_stream_output_with_response(self, response: Stream, output_response: bool=True) -> Tuple[str, object]:
         output = ""
         last_chunk = None
         for chunk in response:


### PR DESCRIPTION
## Summary

- Replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `OpenAILLM.single_generate_async`
- Fix LSP violation in `SiliconFlowLLM.get_stream_output` by extracting the tuple-returning logic into a private `_get_stream_output_with_response()` method

Closes #233
Closes #234

## Changes

### `openai_model.py`
`asyncio.get_event_loop()` is deprecated in Python 3.10+ and raises `RuntimeError` in Python 3.12+ when no running loop exists. Inside a coroutine, `asyncio.get_running_loop()` is always correct.

### `siliconflow_model.py`
`SiliconFlowLLM.get_stream_output()` was returning `Tuple[str, object]` while the parent `OpenAILLM.get_stream_output()` returns `str`, violating the Liskov Substitution Principle. The tuple logic is moved to a private `_get_stream_output_with_response()` method; `get_stream_output()` now correctly returns `str`.

## Test plan

- [ ] Run `single_generate_async` on an `OpenAILLM` instance to confirm no `DeprecationWarning`
- [ ] Run `single_generate` on a `SiliconFlowLLM` instance with `stream=True` to confirm stream output still works correctly
- [ ] Confirm `get_stream_output` on a `SiliconFlowLLM` instance returns `str`