### PR TITLE
fix: pydantic warnings

### DIFF
--- a/evoagentx/actions/agent_generation.py
+++ b/evoagentx/actions/agent_generation.py
@@ -50,8 +50,7 @@ class GeneratedAgent(BaseModule):
         return outputs[similarities.index(max_sim)]
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_prompt(cls, agent: 'GeneratedAgent'):
+    def validate_prompt(self) -> 'GeneratedAgent':
         """Validate and fix the agent's prompt template.
         
         This validator ensures that:
@@ -62,15 +61,16 @@ class GeneratedAgent(BaseModule):
         If there are mismatches in the output sections, it attempts to
         fix them by finding the most similar output name.
         
-        Args:
-            agent: The GeneratedAgent instance to validate.
-            
         Returns:
             The validated and potentially modified GeneratedAgent.
             
         Raises:
             ValueError: If inputs are missing from the prompt or output sections don't match the defined outputs.
         """
+
+        # alias to minimise diff from the pre-Pydantic-2.12 version
+        agent = self
+
         # check whether all the inputs are present in the prompt 
         input_names = [inp.name for inp in agent.inputs]
         prompt_has_inputs = [name in agent.prompt for name in input_names]
@@ -106,7 +106,7 @@ class GeneratedAgent(BaseModule):
             # check whether the generated output names are the same as agent outputs 
             for generated_output in generated_outputs:
                 if generated_output not in outputs_names:
-                    most_similar_output_name = cls.find_output_name(text=generated_output, outputs=outputs_names)
+                    most_similar_output_name = type(agent).find_output_name(text=generated_output, outputs=outputs_names)
                     output_format = output_format.replace(generated_output, most_similar_output_name)
                     logger.warning(f"Couldn't find output name in prompt ('{generated_output}') in agent's outputs. Replace it with the most similar agent output: '{most_similar_output_name}'")
             return "### Output Format" + output_format

--- a/evoagentx/workflow/workflow_graph.py
+++ b/evoagentx/workflow/workflow_graph.py
@@ -84,14 +84,17 @@ class WorkFlowNode(BaseModule):
         return validated_agents
 
     @model_validator(mode="after")
-    @classmethod
-    def check_action_graph(cls, instance: "WorkFlowNode"):
+    def check_action_graph(self) -> "WorkFlowNode":
         """
         Validates that:
         1. All required parameters of execute/async_execute methods are included in inputs
         2. The execute/async_execute methods return dictionaries
         3. All output parameters are present in the returned dictionaries
         """
+
+        # alias to minimise diff from the pre-Pydantic-2.12 version
+        instance = self 
+
         if instance.action_graph is None:
             return instance
         


### PR DESCRIPTION
## Summary

Resolves two `PydanticDeprecatedSince212` warnings emitted on import:
evoagentx/workflow/workflow_graph.py:86: PydanticDeprecatedSince212: Using @model_validator with mode='after' on a classmethod is deprecated.
evoagentx/actions/agent_generation.py:52: PydanticDeprecatedSince212: Using @model_validator with mode='after' on a classmethod is deprecated.

Pydantic 2.12 deprecated the `@classmethod` form of `@model_validator(mode="after")` and points users at the instance-method form, which is also the form expected to be required in Pydantic 3.0.

## Changes

- `WorkFlowNode.check_action_graph`: removed `@classmethod`, changed signature from `(cls, instance)` to `(self)`.
- `GeneratedAgent.validate_prompt`: same conversion, plus `cls.find_output_name(...)` → `type(self).find_output_name(...)` to keep the "called on the class" semantics.

In both cases the function body is unchanged — a local alias (`instance = self` / `agent = self`) keeps the diff minimal. Happy to inline the rename if preferred; let me know.

## Compatibility

- Pydantic 2.0 – 2.11: works (instance-method form has been valid since 2.0).
- Pydantic 2.12+: warning cleared.
- Pydantic 3.0: this is the form the deprecation notice points at as the replacement.
- Pydantic 1.x: not supported, but `model_validator` doesn't exist in 1.x anyway, so this PR doesn't change the supported range.

## Testing

Ran the workflow generation example end-to-end against `qwen3:30b-instruct` via Ollama. Workflow generates, agents instantiate, execution completes — no behaviour change observed, just the two warnings gone.

Reference: https://docs.pydantic.dev/2.13/concepts/validators/#model-after-validator
