### PR TITLE
chore: sync and clean up project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ optimizers = [
     "ujson>=5.9.0"
 ]
 benchmarks = [
-    "sympy"
+    "sympy",
+    "antlr4-python3-runtime==4.11"
 ]
 viz = [
     "matplotlib>=3.10.0"
@@ -147,6 +148,7 @@ all = [
     "cloudpickle",
     "ujson>=5.9.0",
     "sympy",
+    "antlr4-python3-runtime==4.11",
     "matplotlib>=3.10.0"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,17 +25,16 @@ dependencies = [
     "pydantic>=2.9.0",
     "loguru>=0.7.3",
     "python-dotenv>=1.0.0",
-    "httpx>=0.24.1",
     "requests>=2.28.0",
-    "pymongo>=4.6.0",
-    "psycopg2-binary>=2.9.0",
     "openai>=1.55.3",
-    "litellm>=1.55.6",
+    "litellm>=1.75.2",
     "dashscope>=1.23.4",
     "tree_sitter",
     "tree_sitter_python",
-    "antlr4-python3-runtime==4.11",
-    "PyYAML>=6.0"
+    "PyYAML>=6.0",
+    "tqdm>=4.65.0",
+    "regex",
+    "jsonschema"
 ]
 
 [project.optional-dependencies]
@@ -52,41 +51,54 @@ rag = [
     "llama-index",
     "llama-index-vector-stores-faiss",
     "llama-index-graph-stores-neo4j",
+    "llama-index-embeddings-azure-openai",
     "faiss-cpu==1.8.0.post1",
     "sentence-transformers",
     "neo4j",
-    "ollama"
+    "ollama",
+    "docx2txt",
+    "python-pptx"
 ]
 tools = [
     "docker>=6.1.2",
     "googlesearch-python",
     "wikipedia",
-    "mcp",
     "beautifulsoup4",
     "selenium",
     "html2text",
     "fastmcp>=2.2.0,<3.0",
     "PyPDF2",
-    "docx2txt",
-    "python-pptx",
     "Pillow",
-    "exa-py>=2.0.0"
+    "exa-py>=2.0.0",
+    "pymongo>=4.6.0",
+    "psycopg2-binary>=2.9.0",
+    "spacy",
+    "selectolax",
+    "feedparser",
+    "telethon>=1.35.0",
+    "ddgs",
+    "reportlab>=3.6.0",
+    "webdriver-manager>=3.8.0",
+    "browser-use; python_version >= \"3.11\"",
+    "browser-use-py310x; python_version < \"3.11\"",
+    "google-api-python-client>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+    "google-auth-httplib2>=0.1.0"
 ]
 multimodal = [
-    "colpali-engine==0.3.9",
     "torch",
-    "transformers>=4.50.0,<4.51.0",
     "datasets>=3.4.0",
     "voyageai"
 ]
 optimizers = [
     "textgrad>=0.1.8",
-    "dspy"
+    "dspy",
+    "optuna",
+    "cloudpickle",
+    "ujson>=5.9.0"
 ]
 benchmarks = [
-    "sympy",
-    "scipy",
-    "nltk>=3.9.1"
+    "sympy"
 ]
 viz = [
     "matplotlib>=3.10.0"
@@ -95,34 +107,47 @@ all = [
     "llama-index",
     "llama-index-vector-stores-faiss",
     "llama-index-graph-stores-neo4j",
+    "llama-index-embeddings-azure-openai",
     "faiss-cpu==1.8.0.post1",
     "sentence-transformers",
     "neo4j",
     "ollama",
+    "docx2txt",
+    "python-pptx",
     "docker>=6.1.2",
     "googlesearch-python",
     "wikipedia",
-    "mcp",
     "beautifulsoup4",
     "selenium",
     "html2text",
     "fastmcp>=2.2.0,<3.0",
     "PyPDF2",
-    "docx2txt",
-    "python-pptx",
     "Pillow",
-    "colpali-engine==0.3.9",
+    "exa-py>=2.0.0",
+    "pymongo>=4.6.0",
+    "psycopg2-binary>=2.9.0",
+    "spacy",
+    "selectolax",
+    "feedparser",
+    "telethon>=1.35.0",
+    "ddgs",
+    "reportlab>=3.6.0",
+    "webdriver-manager>=3.8.0",
+    "browser-use; python_version >= \"3.11\"",
+    "browser-use-py310x; python_version < \"3.11\"",
+    "google-api-python-client>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+    "google-auth-httplib2>=0.1.0",
     "torch",
-    "transformers>=4.50.0,<4.51.0",
     "datasets>=3.4.0",
     "voyageai",
     "textgrad>=0.1.8",
     "dspy",
+    "optuna",
+    "cloudpickle",
+    "ujson>=5.9.0",
     "sympy",
-    "scipy",
-    "nltk>=3.9.1",
-    "matplotlib>=3.10.0",
-    "exa-py>=2.0.0"
+    "matplotlib>=3.10.0"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# dev
 pytest
 pytest-cov
 pytest-mock
@@ -6,84 +7,78 @@ pytest-subtests
 pytest-json-report
 ruff
 
-sympy
+# core
 overdue
-scipy>=1.9.0
-setuptools
-tree_sitter
-tree_sitter_python
-antlr4-python3-runtime==4.11
 tenacity
 networkx>=3.3
-nltk>=3.9.1
 numpy>=1.26.4
+pandas>=2.2.3
+pydantic>=2.9.0
+loguru>=0.7.3
+python-dotenv>=1.0.0
+requests>=2.28.0
 openai>=1.55.3
 litellm>=1.75.2
-litellm-enterprise>=0.1.19
-litellm-proxy-extras>=0.2.16
 dashscope>=1.23.4
-pydantic>=2.9.0
-# pydantic>=2.9.0,<=2.10.6
-# pydantic_core>=2.23.2,<=2.27.2
-loguru>=0.7.3 
-pandas>=2.2.3
-httpx>=0.24.1
-python-dotenv>=1.0.0
-pymongo>=4.6.0
-psycopg2-binary>=2.9.0
-matplotlib>=3.10.0
-# --extra-index-url https://download.pytorch.org/whl/cu118
-# torch==2.2.1 
-# torchvision==0.17.1 
-# torchaudio==2.2.1
-datasets>=3.4.0
-faiss-cpu==1.8.0.post1
-# faiss-gpu
-textgrad>=0.1.8
-dspy
+tree_sitter
+tree_sitter_python
+PyYAML>=6.0
+tqdm>=4.65.0
+regex
+jsonschema
 
-bs4
 # rag
-# Should install torch
-neo4j
-ollama
 llama-index
 llama-index-vector-stores-faiss
 llama-index-graph-stores-neo4j
 llama-index-embeddings-azure-openai
+faiss-cpu==1.8.0.post1
 sentence-transformers
+neo4j
+ollama
 docx2txt
-python-pptx 
-Pillow
+python-pptx
 
 # tools
-docker>=6.0.0
+docker>=6.1.2
 googlesearch-python>=1.2.0
-ddgs # Dux Distributed Global Search
-exa-py>=2.0.0 # Exa AI-powered search
 wikipedia>=1.4.0
-fastmcp>=0.1.0
-requests>=2.28.0
-reportlab>=3.6.0
-PyPDF2>=3.0.0
+beautifulsoup4
 selenium>=4.0.0
-webdriver-manager>=3.8.0
 html2text>=2020.1.16
-browser-use; python_version >= "3.11"
-browser-use-py310; python_version < "3.11"
-mcp>=0.1.0
+fastmcp>=2.2.0,<3.0
+PyPDF2>=3.0.0
+Pillow
+exa-py>=2.0.0
+pymongo>=4.6.0
+psycopg2-binary>=2.9.0
+spacy
+selectolax
+feedparser
 telethon>=1.35.0
+ddgs
+reportlab>=3.6.0
+webdriver-manager>=3.8.0
+browser-use; python_version >= "3.11"
+browser-use-py310x; python_version < "3.11"
 google-api-python-client>=2.0.0
 google-auth-oauthlib>=1.0.0
 google-auth-httplib2>=0.1.0
 
-# Multimodal dependencies
-colpali-engine==0.3.9
-Pillow
-# torch
-transformers>=4.50.0,<4.51.0
+# multimodal
+# torch  # uncomment and pin as needed, e.g. for cu118: --extra-index-url https://download.pytorch.org/whl/cu118
+datasets>=3.4.0
 voyageai
 
-feedparser
-markdown
+# optimizers
+textgrad>=0.1.8
+dspy
+optuna
+cloudpickle
 ujson>=5.9.0
+
+# benchmarks
+sympy
+
+# viz
+matplotlib>=3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,6 +79,7 @@ ujson>=5.9.0
 
 # benchmarks
 sympy
+antlr4-python3-runtime==4.11
 
 # viz
 matplotlib>=3.10.0


### PR DESCRIPTION
- Remove unused packages: colpali-engine, transformers (multimodal), scipy/nltk (benchmarks), mcp (tools; fastmcp is used instead), antlr4-python3-runtime and httpx (transitive deps only), litellm-enterprise/litellm-proxy-extras (internal packages)
- Move pymongo and psycopg2-binary from base deps to tools extra
- Move docx2txt and python-pptx from tools to rag extra (used via llama-index)
- Add missing direct dependencies to correct extras: tqdm/regex/jsonschema (base), llama-index-embeddings-azure-openai (rag), spacy/selectolax/ feedparser/telethon/ddgs/reportlab/webdriver-manager/browser-use/ google-auth-* (tools), optuna/cloudpickle/ujson (optimizers)
- Update litellm minimum version from 1.55.6 to 1.75.2
- Regenerate [all] extra to match all individual extras
- Restructure requirements.txt to mirror pyproject.toml sections