### PR TITLE
docs: add missing import os in OpenAI API key example

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 Once the API key is set, initialise the LLM with:
 
 ```python
+import os
 from evoagentx.models import OpenAILLMConfig, OpenAILLM
 
 # Load the API key from environment


### PR DESCRIPTION
The standalone code example in the **"LLM Configuration"** section uses `os.getenv("OPENAI_API_KEY")` but does not import the `os` module. Running this snippet as written raises:

```
NameError: name 'os' is not defined
```

**Root cause:** An earlier code block (Option 1 env setup) does `import os`, but the LLM configuration snippet is meant to be a self-contained example and starts with `from evoagentx.models import ...` without importing `os` first.

**Fix:** Add `import os` at the top of the example block so it runs correctly when copy-pasted.

Docs-only — no logic change.